### PR TITLE
Allow setting falsey config values

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = {
         _paceConfig = false;
       } else {
         Object.keys(_defaultPaceConfig).forEach(function (key) {
-          _paceConfig[key] = baseConfig.pace[key] || _defaultPaceConfig[key];
+          _paceConfig[key] = baseConfig.pace.hasOwnProperty(key) ? baseConfig.pace[key] : _defaultPaceConfig[key];
         });
       }
     } else {


### PR DESCRIPTION
I was having trouble setting config options to falsey values. For example, attempting to disable `restartOnRequestAfter` or `elements` by setting them to `false` would result in the default value, but setting it to a positive number would work fine.

This change checks for the existence of a property on the `baseConfig.pace` object when merging with the default values, rather than testing the truthiness of the value.
