### PR TITLE
Adds "demoURL" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "defaultBlueprint": "pace",
+    "demoURL": "https://vectart.github.io/ember-cli-pace/",
     "after": [
       "ember-cli-content-security-policy"
     ]


### PR DESCRIPTION
Sites likes emberaddons.com and emberobserver.com will display a link to "demoURL".
