### PR TITLE
Add README link to detailed configuration info

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ var ENV = {
     
     // pace-specific options
     // learn more on http://github.hubspot.com/pace/#configuration
+    //           and https://github.com/HubSpot/pace/blob/master/pace.coffee#L1-L72
     catchupTime: 50,
     initialRate: .01,
     minTime: 100,


### PR DESCRIPTION
Pace's documentation for its configuration is split between the documentation site and the comments in the source on the defaults. This adds a link to the latter as well.
