### PR TITLE
Fix package and CSS errors on install.

### DIFF
--- a/blueprints/pace/index.js
+++ b/blueprints/pace/index.js
@@ -2,6 +2,6 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('vectart/pace#master');
+    return this.addBowerPackageToProject('vectart/pace', 'master');
   }
 };

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var UglifyJS = require("uglify-js");
 var _paceConfig = {};
 var _defaultPaceConfig = {
   color: 'blue',
-  theme: 'material',
+  theme: 'minimal',
   catchupTime: 50,
   initialRate: .01,
   minTime: 100,


### PR DESCRIPTION
This PR fixes the two errors that appeared recently - one is due to a deprecation, the other because the default theme `material` is not included in Pace anymore.
